### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ After building the project, you can run the engine by executing the following co
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the MIT License.  2025


### PR DESCRIPTION
Should always have the current year in the MIT license, as older licenses can have updates and sometimes that creates confusion.